### PR TITLE
Bump dgsVersion from 8.5.0 to 9.0.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
 }
 
 val junitVersion = "5.10.2"
-val dgsVersion = "8.5.0"
+val dgsVersion = "9.0.3"
 
 dependencies {
     implementation("org.wiremock:wiremock:3.5.2")


### PR DESCRIPTION
Bumps `dgsVersion` from 8.5.0 to 9.0.3.

Updates `com.netflix.graphql.dgs:graphql-dgs-platform-dependencies` from 8.5.0 to 9.0.3
- [Release notes](https://github.com/Netflix/dgs-framework/releases)
- [Commits](https://github.com/Netflix/dgs-framework/compare/v8.5.0...v9.0.3)

Updates `com.netflix.graphql.dgs:graphql-dgs-extended-scalars` from 8.5.0 to 9.0.3
- [Release notes](https://github.com/Netflix/dgs-framework/releases)
- [Commits](https://github.com/Netflix/dgs-framework/compare/v8.5.0...v9.0.3)

Updates `com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter` from 8.5.0 to 9.0.3
- [Release notes](https://github.com/Netflix/dgs-framework/releases)
- [Commits](https://github.com/Netflix/dgs-framework/compare/v8.5.0...v9.0.3)

---
updated-dependencies:
- dependency-name: com.netflix.graphql.dgs:graphql-dgs-platform-dependencies dependency-type: direct:production update-type: version-update:semver-major
- dependency-name: com.netflix.graphql.dgs:graphql-dgs-extended-scalars dependency-type: direct:production update-type: version-update:semver-major
- dependency-name: com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter dependency-type: direct:production update-type: version-update:semver-major ...